### PR TITLE
Adding a holding page for examples and shims

### DIFF
--- a/source/comingsoon.html
+++ b/source/comingsoon.html
@@ -1,0 +1,16 @@
+---
+title: Page temporarily unavailable
+id: commingsoon
+categories: [pages]
+layout: sub-page
+redirect_from:
+  - /comingsoon.html
+---
+<section class="about-content wrapper">
+	<p>The URL you have used to get to this page is currently out of service due to website maintenance, and should be working again shortly. If this causes a problem in your software or workflow please contact the IIIF Community and Communications Officer, Sheila Rabun, at srabun [at] iiif.io </p>
+	<p>The pages which are affected by this work include:</p>
+	<ul>
+	  <li>/api/image/*/example/reference - a IIIF reference implementation</li>
+	  <li>/shims - example shims for different software solutions and collections. </li>
+	</ul>
+</section>


### PR DESCRIPTION
Adding a page explaining the examples and shims are currently unavailable. 